### PR TITLE
Replace deprecated `node.set` with `node.default`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 Berksfile.lock
 Vagrantfile.erb
 Vagrantfile.local.rb
+.idea/

--- a/attributes/debian.rb
+++ b/attributes/debian.rb
@@ -1,2 +1,2 @@
-set['debian']['mirror'] = 'http://mirror.cc.columbia.edu/debian'
-set['debian']['stable_updates'] = false
+default['debian']['mirror'] = 'http://mirror.cc.columbia.edu/debian'
+default['debian']['stable_updates'] = false

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -19,10 +19,10 @@
 
 if node[:platform] == 'debian'
   node.default['debian']['mirror'] = 'http://mirror.rit.edu/debian'
-  node.set['debian']['deb_src'] = true
+  node.default['debian']['deb_src'] = true
   platform_recipe = 'debian'
 elsif node[:platform] == 'ubuntu'
-  node.set['ubuntu']['deb_src'] = true
+  node.default['ubuntu']['deb_src'] = true
   platform_recipe = 'ubuntu'
 else
   raise "Unsupported platform: #{node[:platform]}"

--- a/recipes/citrix.rb
+++ b/recipes/citrix.rb
@@ -61,8 +61,8 @@ ruby_block 'citrix-get-url' do
       .map{|el| el['rel']}
       .select{ |rel| rel.include?("icaclient") && rel.include?("amd64") }
       .first
-    link = "https:#{final_rel}" 
-    node.set['desktop_citrix_onetime_url'] = link
+    link = "https:#{final_rel}"
+    node.default['desktop_citrix_onetime_url'] = link
   end
   not_if{ citrix_deb_is_valid.call }
 end


### PR DESCRIPTION
@http-418 any compatibility reason to use set rather than default here? Cuts down on annoying deprecation warnings to update. Nbd either way.
