### PR TITLE
Includes `user` recipe dependency within `virtualbox` recipe.

### DIFF
--- a/recipes/virtualbox.rb
+++ b/recipes/virtualbox.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe 'apt'
+include_recipe 'user'
 
 apt_repository 'virtualbox' do
   uri 'http://download.virtualbox.org/virtualbox/debian'


### PR DESCRIPTION
Because it doesn't work without it.