### PR TITLE
Includes `backports` recipe dependency within `java` recipe.

### DIFF
--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -21,6 +21,8 @@ node.default[:java][:install_flavor] = 'oracle'
 node.default[:java][:jdk_version] = '8'
 node.default[:java][:oracle][:accept_oracle_download_terms] = true
 
+include_recipe 'desktop::backports'
+
 # Install a packaged java to satisfy Debian deps.
 package 'openjdk-8-jdk'
 


### PR DESCRIPTION
Because it doesn't work without it.