### PR TITLE
safer rbenv global fallback value

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+def most_recent_ruby_version
+  node[:rbenv][:rubies].map do |version|
+    Gem::Version.new(version)
+  end.sort.map(&:to_s).last
+end
+
 # Install bundler gem in every ruby.
 # (Vagrant requires bundler <= 1.10.6)
 # see attributes/ruby.rb!
@@ -30,7 +36,8 @@ node.default[:rbenv][:gems] = node[:rbenv][:rubies]
 include_recipe 'ruby_build'
 include_recipe 'ruby_rbenv::system'
 
-rbenv_global node[:rbenv].fetch(:rbenv_global, '2.3.0')
+Gem::Version
+rbenv_global node[:rbenv].fetch(:rbenv_global, most_recent_ruby_version)
 
 unless node[:rbenv].fetch(:keep_old_rubies, false)
   ruby_block 'uninstall-old-rubies' do


### PR DESCRIPTION
If '2.3.0' isn't an installed version via the `[:rbenv][:rubies]` attribute the recipe blows up. This should be safer, in case the `[:rbenv][:rbenv_global]` attribute isn't specified.