### PR TITLE
Update spotify and libgcrypt recipes

### DIFF
--- a/recipes/libgcrypt11.rb
+++ b/recipes/libgcrypt11.rb
@@ -31,7 +31,7 @@ if node['platform'] == 'debian'
     checksum '4b44bc35225aa51ce70a982c49bf320cb0861556e04a867e4a9231fb8dd31820'
     notifies :install, 'dpkg_package[libgcrypt11]', :immediately
   end
-  
+
   dpkg_package 'libgcrypt11' do
     package_name libgcrypt11_path
     action :nothing
@@ -42,7 +42,11 @@ if node['platform'] == 'debian'
     notifies :install, 'dpkg_package[libgcrypt11]', :immediately
   end
 elsif node['platform'] == 'ubuntu'
-  # This will blow up on Ubuntu releases newer than 14.04.
-  # I guess that's 2016's problem.
-  package 'libgcrypt11'
+  version = Gem::Version.new(node[:platform_version])
+
+  if version > Gem::Version.new('14.04')
+    package 'libgcrypt20'
+  else
+    package 'libgcrypt11'
+  end
 end

--- a/recipes/spotify.rb
+++ b/recipes/spotify.rb
@@ -20,12 +20,14 @@
 include_recipe 'apt'
 include_recipe 'desktop::libgcrypt11'
 
+package 'dirmngr'
+
 apt_repository 'spotify' do
   uri 'http://repository.spotify.com'
   components ['non-free']
   distribution 'stable'
   keyserver 'keyserver.ubuntu.com'
-  key 'D2C19886'
+  key '0DF731E45CE24F27EEEB1450EFDC8610341D9410'
 end
 
 package 'spotify-client'


### PR DESCRIPTION
* Update spotify recipe to use current key.
* Update libgcrypt recipe to use more recent version of libgcrypt on
  newer versions of ubuntu.

Test kitchen builds ran successfully on all platforms.